### PR TITLE
Add user commands for YAML file and help message

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,19 @@ python analysis/dataFrameAnalysis.py /path/to/your/config.yaml
 
 3. **View the Results**: The results, including histograms and any other output, will be saved in the specified output directory.
 
+### Command-Line Options
+
+The script supports the following command-line options:
+
+- `config_file`: Path to the YAML configuration file.
+- `-h` or `--help`: Display the help message.
+
+To display the help message, run:
+
+```bash
+python analysis/dataFrameAnalysis.py -h
+```
+
 ## Configuration
 
 The analysis is configured through a YAML file. Below is an example configuration:

--- a/analysis/dataFrameAnalysis.py
+++ b/analysis/dataFrameAnalysis.py
@@ -7,6 +7,7 @@ import os
 import yaml
 import numpy as np
 from typing import List, Dict, Tuple, Any
+import argparse
 
 
 def setup_logger():
@@ -45,6 +46,17 @@ def setup_logger():
     logger.addHandler(handler)
 
     return logger
+
+
+def parse_arguments():
+    """
+    Parse command-line arguments for the script.
+
+    :return: Parsed arguments.
+    """
+    parser = argparse.ArgumentParser(description="Run the DataFrame analysis with a specified YAML configuration file.")
+    parser.add_argument("config_file", type=str, help="Path to the YAML configuration file.")
+    return parser.parse_args()
 
 
 class DataFrameAnalyzer:
@@ -305,11 +317,10 @@ def plot_histograms(histograms: List[dst.ROOT.TH1F]) -> None:
 if __name__ == "__main__":
     logger = setup_logger()
 
-    # Path to the analysis configuration file
-    analysis_config = "/home/zane/software/new_analysis/txHybridDF/config/txhybrid_config.yaml"
+    args = parse_arguments()
 
     # Initialize the DataFrameAnalyzer with the configuration file
-    analyzer = DataFrameAnalyzer(analysis_config)
+    analyzer = DataFrameAnalyzer(args.config_file)
 
     # Run the analysis and get the list of histograms
     my_histograms = analyzer.run_analysis()


### PR DESCRIPTION
Add command-line argument parsing and help message functionality to `analysis/dataFrameAnalysis.py`.

* **Command-line Argument Parsing**:
  - Add `argparse` to parse command-line arguments for the YAML file and help message.
  - Extract argument parsing to a function `parse_arguments`.
  - Remove the hardcoded `analysis_config` path.
  - Update the `__main__` section to use the parsed YAML file path.

* **Help Message**:
  - Add a help message that describes the usage of the script.

* **Documentation**:
  - Update `README.md` to include instructions for providing the YAML file via command line and displaying the help message.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ZGerber/taAnalysis/pull/3?shareId=b1e63984-3e69-46b5-a735-fb4ec3206503).